### PR TITLE
Make sure scripts work on dash, add missing binary options

### DIFF
--- a/install_conda.sh
+++ b/install_conda.sh
@@ -5,29 +5,56 @@ CDSP_TAG="v2.0.0"
 SYSTEM=$(uname -s)
 ARCH=$(uname -m)
 
-if [ "$SYSTEM" == "Linux" ]
+if [ "$SYSTEM" = "Linux" ]
 then
-    if [ "$ARCH" == "x86_64" ]
+    if [ "$ARCH" = "x86_64" ]
     then
-        ARCHIVE_NAME="camilladsp-linux-amd64.tar.gz"
-    elif [ "$ARCH" == "aarch64" ]
+        LONG_BIT=$(getconf LONG_BIT)
+        if [ "$LONG_BIT" = "32" ]
+        then
+            echo "Running on Linux, amd64, with 32-bit userland"
+            echo "Error, no binary available for this combination!"
+            exit 1
+        else
+            echo "Running on Linux, amd64"
+            ARCHIVE_NAME="camilladsp-linux-amd64.tar.gz"
+        fi
+    elif [ "$ARCH" = "aarch64" ]
     then
-        ARCHIVE_NAME="camilladsp-linux-aarch64.tar.gz"
+        LONG_BIT=$(getconf LONG_BIT)
+        if [ "$LONG_BIT" = "32" ]
+        then
+            echo "Running on Linux, aarch64, with 32-bit userland"
+            ARCHIVE_NAME="camilladsp-linux-armv7.tar.gz"
+        else
+            echo "Running on Linux, aarch64"
+            ARCHIVE_NAME="camilladsp-linux-aarch64.tar.gz"
+        fi
+    elif [ "$ARCH" = "armv7l" ]
+    then
+        echo "Running on Linux, armv7l"
+        ARCHIVE_NAME="camilladsp-linux-armv7.tar.gz"
+    elif [ "$ARCH" = "armv6l" ]
+    then
+        echo "Running on Linux, armv6l"
+        ARCHIVE_NAME="camilladsp-linux-armv6.tar.gz"
     else
-        echo "Unsupported CPU type $ARCH!"
+        echo "There is no prebuilt binary available for CPU type $ARCH! on Linux!"
         exit 1
     fi
-elif [ "$SYSTEM" == "Darwin" ]
+elif [ "$SYSTEM" = "Darwin" ]
 then
     ARCH=$(uname -m)
-    if [ "$ARCH" == "x86_64" ]
+    if [ "$ARCH" = "x86_64" ]
     then
+        echo "Running on MacOS, amd64"
         ARCHIVE_NAME="camilladsp-macos-amd64.tar.gz"
     elif [ "$ARCH" == "arm64" ]
     then
+        echo "Running on MacOS, aarch64"
         ARCHIVE_NAME="camilladsp-macos-aarch64.tar.gz"
     else
-        echo "Unsupported CPU type $ARCH!"
+        echo "There is no prebuilt binary available for CPU type $ARCH! on MacOS!"
         exit 1
     fi
 else
@@ -35,42 +62,42 @@ else
     exit 1
 fi
 
-if [[ -z $1 ]]; then
+if [ -z $1 ]; then
     INSTALL_ROOT="$HOME/camilladsp"
 else
     INSTALL_ROOT=$1
 fi
 
-if [[ -z $CONDA_PREFIX ]]; then
+if [ -z $CONDA_PREFIX ]; then
     echo "CONDA_PREFIX environment variable is not set, looking for conda in standard locations"
     if [ -f ~/opt/anaconda3/etc/profile.d/conda.sh ]; then
         echo "Using user Anaconda at ~/opt/anaconda3"
-        source ~/opt/anaconda3/etc/profile.d/conda.sh
+        . ~/opt/anaconda3/etc/profile.d/conda.sh
     elif [ -f ~/anaconda3/etc/profile.d/conda.sh ]; then
         echo "Using user Anaconda at ~/anaconda3"
-        source ~/anaconda3/etc/profile.d/conda.sh
+        . ~/anaconda3/etc/profile.d/conda.sh
     elif [ -f /opt/anaconda3/etc/profile.d/conda.sh ]; then
         echo "Using system Anaconda at /opt/anaconda3"
-        source /opt/anaconda3/etc/profile.d/conda.sh
+        . /opt/anaconda3/etc/profile.d/conda.sh
     elif [ -f ~/opt/miniconda3/etc/profile.d/conda.sh ]; then
         echo "Using user miniconda at ~/opt/miniconda3"
-        source ~/opt/miniconda3/etc/profile.d/conda.sh
+        . ~/opt/miniconda3/etc/profile.d/conda.sh
     elif [ -f ~/miniconda3/etc/profile.d/conda.sh ]; then
         echo "Using user miniconda at ~/miniconda3"
-        source ~/miniconda3/etc/profile.d/conda.sh
+        . ~/miniconda3/etc/profile.d/conda.sh
     elif [ -f ~/opt/miniforge3/etc/profile.d/conda.sh ]; then
         echo "Using user miniforge at ~/opt/miniforge3"
-        source ~/opt/miniforge3/etc/profile.d/conda.sh
+        . ~/opt/miniforge3/etc/profile.d/conda.sh
     elif [ -f ~/miniforge3/etc/profile.d/conda.sh ]; then
         echo "Using user miniforge at ~/miniforge3"
-        source ~/miniforge3/etc/profile.d/conda.sh
+        . ~/miniforge3/etc/profile.d/conda.sh
     else
         echo "No conda found!"
         exit 1
     fi
 else
     echo "Using conda from $CONDA_PREFIX"
-    source $CONDA_PREFIX/etc/profile.d/conda.sh
+    . $CONDA_PREFIX/etc/profile.d/conda.sh
 fi
 
 conda activate camillagui
@@ -99,6 +126,11 @@ if [ $? -ne 0 ]; then
     echo "Failed to create bin dir"
     exit 1
 fi
+mkdir -p "$INSTALL_ROOT/gui"
+if [ $? -ne 0 ]; then
+    echo "Failed to create gui dir"
+    exit 1
+fi
 
 echo "--- Download Camillagui"
 if [ -f camillagui.zip ]; then
@@ -109,11 +141,24 @@ if [ $? -ne 0 ]; then
     echo "Failed to download gui"
     exit 1
 fi
+
 echo "--- Uncompress Camillagui to $INSTALL_ROOT/gui"
-mkdir camillagui
-unzip -o camillagui.zip -d "$INSTALL_ROOT/gui"
-if [ $? -ne 0 ]; then
-    echo "Failed to uncompress gui"
+if command -v unar &> /dev/null
+then
+    unar -f camillagui.zip -o "$INSTALL_ROOT/gui"
+    if [ $? -ne 0 ]; then
+        echo "Failed to uncompress gui"
+        exit 1
+    fi
+elif command -v unzip &> /dev/null
+then
+    unzip -o camillagui.zip -d "$INSTALL_ROOT/gui"
+    if [ $? -ne 0 ]; then
+        echo "Failed to uncompress gui"
+        exit 1
+    fi
+else
+    echo "Error, no tool for unpacking .zip found, install either unzip or unar and try again"
     exit 1
 fi
 

--- a/install_venv.sh
+++ b/install_venv.sh
@@ -5,29 +5,56 @@ CDSP_TAG="v2.0.0"
 SYSTEM=$(uname -s)
 ARCH=$(uname -m)
 
-if [ "$SYSTEM" == "Linux" ]
+if [ "$SYSTEM" = "Linux" ]
 then
-    if [ "$ARCH" == "x86_64" ]
+    if [ "$ARCH" = "x86_64" ]
     then
-        ARCHIVE_NAME="camilladsp-linux-amd64.tar.gz"
-    elif [ "$ARCH" == "aarch64" ]
+        LONG_BIT=$(getconf LONG_BIT)
+        if [ "$LONG_BIT" = "32" ]
+        then
+            echo "Running on Linux, amd64, with 32-bit userland"
+            echo "Error, no binary available for this combination!"
+            exit 1
+        else
+            echo "Running on Linux, amd64"
+            ARCHIVE_NAME="camilladsp-linux-amd64.tar.gz"
+        fi
+    elif [ "$ARCH" = "aarch64" ]
     then
-        ARCHIVE_NAME="camilladsp-linux-aarch64.tar.gz"
+        LONG_BIT=$(getconf LONG_BIT)
+        if [ "$LONG_BIT" = "32" ]
+        then
+            echo "Running on Linux, aarch64, with 32-bit userland"
+            ARCHIVE_NAME="camilladsp-linux-armv7.tar.gz"
+        else
+            echo "Running on Linux, aarch64"
+            ARCHIVE_NAME="camilladsp-linux-aarch64.tar.gz"
+        fi
+    elif [ "$ARCH" = "armv7l" ]
+    then
+        echo "Running on Linux, armv7l"
+        ARCHIVE_NAME="camilladsp-linux-armv7.tar.gz"
+    elif [ "$ARCH" = "armv6l" ]
+    then
+        echo "Running on Linux, armv6l"
+        ARCHIVE_NAME="camilladsp-linux-armv6.tar.gz"
     else
-        echo "Unsupported CPU type $ARCH!"
+        echo "There is no prebuilt binary available for CPU type $ARCH! on Linux!"
         exit 1
     fi
-elif [ "$SYSTEM" == "Darwin" ]
+elif [ "$SYSTEM" = "Darwin" ]
 then
     ARCH=$(uname -m)
-    if [ "$ARCH" == "x86_64" ]
+    if [ "$ARCH" = "x86_64" ]
     then
+        echo "Running on MacOS, amd64"
         ARCHIVE_NAME="camilladsp-macos-amd64.tar.gz"
     elif [ "$ARCH" == "arm64" ]
     then
+        echo "Running on MacOS, aarch64"
         ARCHIVE_NAME="camilladsp-macos-aarch64.tar.gz"
     else
-        echo "Unsupported CPU type $ARCH!"
+        echo "There is no prebuilt binary available for CPU type $ARCH! on MacOS!"
         exit 1
     fi
 else
@@ -35,7 +62,7 @@ else
     exit 1
 fi
 
-if [[ -z $1 ]]; then
+if [ -z $1 ]; then
     INSTALL_ROOT="$HOME/camilladsp"
 else
     INSTALL_ROOT=$1
@@ -76,6 +103,11 @@ if [ $? -ne 0 ]; then
     echo "Failed to create bin dir"
     exit 1
 fi
+mkdir -p "$INSTALL_ROOT/gui"
+if [ $? -ne 0 ]; then
+    echo "Failed to create gui dir"
+    exit 1
+fi
 
 echo "--- Download Camillagui"
 if [ -f camillagui.zip ]; then
@@ -86,11 +118,24 @@ if [ $? -ne 0 ]; then
     echo "Failed to download gui"
     exit 1
 fi
+
 echo "--- Uncompress Camillagui to $INSTALL_ROOT/gui"
-mkdir camillagui
-unzip -o camillagui.zip -d "$INSTALL_ROOT/gui"
-if [ $? -ne 0 ]; then
-    echo "Failed to uncompress gui"
+if command -v unar &> /dev/null
+then
+    unar -f camillagui.zip -o "$INSTALL_ROOT/gui"
+    if [ $? -ne 0 ]; then
+        echo "Failed to uncompress gui"
+        exit 1
+    fi
+elif command -v unzip &> /dev/null
+then
+    unzip -o camillagui.zip -d "$INSTALL_ROOT/gui"
+    if [ $? -ne 0 ]; then
+        echo "Failed to uncompress gui"
+        exit 1
+    fi
+else
+    echo "Error, no tool for unpacking .zip found, install either unzip or unar and try again"
     exit 1
 fi
 


### PR DESCRIPTION
Inspired by https://github.com/HEnquist/camilladsp-setupscripts/pull/8, but without requiring `bash`. 
Also add the missing binary builds, and optionally use `unar` instead of `unzip`